### PR TITLE
Return genesis transactions from /info

### DIFF
--- a/src/did_indy/driver/api/namespaces.py
+++ b/src/did_indy/driver/api/namespaces.py
@@ -20,6 +20,7 @@ class NamespaceInfo(BaseModel):
     namespace: str
     nym: str
     did: str
+    genesis_transaction: str
 
 
 class NamespaceList(BaseModel):
@@ -39,6 +40,7 @@ async def get_info(ledgers: LedgersDep, store: StoreDep) -> NamespaceList:
                 namespace=namespace,
                 nym=nym,
                 did=f"did:indy:{namespace}:{nym}",
+                genesis_transaction = ledgers.ledgers[namespace].genesis_txns_cache,
             )
         )
     return NamespaceList(namespaces=results)

--- a/src/did_indy/driver/api/namespaces.py
+++ b/src/did_indy/driver/api/namespaces.py
@@ -40,7 +40,7 @@ async def get_info(ledgers: LedgersDep, store: StoreDep) -> NamespaceList:
                 namespace=namespace,
                 nym=nym,
                 did=f"did:indy:{namespace}:{nym}",
-                genesis_transaction = ledgers.ledgers[namespace].genesis_txns_cache,
+                genesis_transaction = ledgers.ledgers[namespace].genesis_txns_cache or "",
             )
         )
     return NamespaceList(namespaces=results)

--- a/src/did_indy/driver/api/namespaces.py
+++ b/src/did_indy/driver/api/namespaces.py
@@ -40,7 +40,7 @@ async def get_info(ledgers: LedgersDep, store: StoreDep) -> NamespaceList:
                 namespace=namespace,
                 nym=nym,
                 did=f"did:indy:{namespace}:{nym}",
-                genesis_transaction = ledgers.ledgers[namespace].genesis_txns_cache or "",
+                genesis_transaction=ledgers.ledgers[namespace].genesis_txns_cache or "",
             )
         )
     return NamespaceList(namespaces=results)

--- a/src/did_indy/driver/api/namespaces.py
+++ b/src/did_indy/driver/api/namespaces.py
@@ -33,14 +33,14 @@ class NamespaceList(BaseModel):
 async def get_info(ledgers: LedgersDep, store: StoreDep) -> NamespaceList:
     """Return loaded namespaces."""
     results = []
-    for namespace in ledgers.ledgers.keys():
+    for namespace, pool in ledgers.ledgers.items():
         nym, _ = await get_nym_and_key(store, namespace)
         results.append(
             NamespaceInfo(
                 namespace=namespace,
                 nym=nym,
                 did=f"did:indy:{namespace}:{nym}",
-                genesis_transaction=ledgers.ledgers[namespace].genesis_txns_cache or "",
+                genesis_transaction=pool.genesis_txns_cache or "",
             )
         )
     return NamespaceList(namespaces=results)


### PR DESCRIPTION
Plugin needs genesis transaction info in order to initialise its ledgers, so we return it from the /info endpoint